### PR TITLE
Upgrade to Percona 5.7.18-14

### DIFF
--- a/percona-server57.rb
+++ b/percona-server57.rb
@@ -2,8 +2,8 @@
 class PerconaServer57 < Formula
   desc "Drop-in MySQL replacement"
   homepage "https://www.percona.com"
-  url "https://www.percona.com/downloads/Percona-Server-5.7/Percona-Server-5.7.11-4/source/tarball/percona-server-5.7.11-4.tar.gz"
-  sha256 "3634d2262e646db11b03837561acb0e084f33e5a597957506cf4c333ea811921"
+  url "https://www.percona.com/downloads/Percona-Server-5.7/Percona-Server-5.7.18-14/source/tarball/percona-server-5.7.18-14.tar.gz"
+  sha256 "4c617e2f9a1c601caebb5ff470c675e3d03ba3b8071cd3261ae24fe11671e3bd"
 
   keg_only 'Keg only with versioned data directory to allow multiple versions on one system.  See: https://www.percona.com/blog/2014/08/26/mysqld_multi-how-to-run-multiple-instances-of-mysql/'
 
@@ -123,8 +123,6 @@ class PerconaServer57 < Formula
     # Fix up the control script and link into bin
     inreplace "#{prefix}/support-files/mysql.server" do |s|
       s.gsub!(/^(PATH=".*)(")/, "\\1:#{HOMEBREW_PREFIX}/bin\\2")
-      # pidof can be replaced with pgrep from proctools on Mountain Lion
-      s.gsub!(/pidof/, "pgrep") if MacOS.version >= :mountain_lion
     end
 
     bin.install_symlink prefix/"support-files/mysql.server"


### PR DESCRIPTION
What
----------------------
Upgrades the percona-server57 recipe to use version 5.7.18-14.

Why
----------------------
New installs of the existing version were exhibiting strange behavior with macOS Sierra. Specifically, the database intialization step was hanging and would not exit/complete successfully. Building/installing this version works as expected.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------

See separate private PR linked here for QA instructions.