### PR TITLE
Percona/Mongo updates and bottles

### DIFF
--- a/mongodb24.rb
+++ b/mongodb24.rb
@@ -4,10 +4,11 @@ class Mongodb24 < Formula
   sha256 "b239a065a1197f811a3908bdee8d535564b94f2d79da893935e38831ebbac8b3"
 
   bottle do
-    cellar :any
-    sha256 "004b4e3bfdb5ee0c00b5568383b5012059d057cc30248f5604afd34fd3cb8382" => :yosemite
-    sha256 "c6310fd5ea6f665c1d6aec573024b729c912865fcad25ce6723a293bcde82db7" => :mavericks
-    sha256 "d3d6d653817a8e6127d9efa62d0f7338c67d15217acb323b5ad49ae853a719da" => :mountain_lion
+    root_url "https://s3.amazonaws.com/sportngin-homebrew-bottles"
+    cellar :any_skip_relocation
+    rebuild 1
+    sha256 "b83a20e8e440726fc0798d24d17a3781b811e959239d19d5ef0ee22aba7f5b83" => :el_capitan
+    sha256 "4e6dbc25e9cb2a82d1047b4cc96314a3afe1afc6fb2f4d5f464201661419d644" => :sierra
   end
 
   patch do

--- a/percona-server55.rb
+++ b/percona-server55.rb
@@ -38,10 +38,6 @@ class PerconaServer55 < Formula
   end
 
   def install
-    # Build without compiler or CPU specific optimization flags to facilitate
-    # compilation of gems and other software that queries `mysql-config`.
-    ENV.minimal_optimization
-
     # Make sure that data directory exists
     (var/destination).mkpath
 

--- a/percona-server55.rb
+++ b/percona-server55.rb
@@ -10,7 +10,9 @@ class PerconaServer55 < Formula
 
   bottle do
     root_url "https://s3.amazonaws.com/sportngin-homebrew-bottles"
-    sha256 "1202b15ad2add10daee1b22cd92af0fb0e27847d965641cf5c156a5d343519a5" => :el_capitan
+    rebuild 1
+    # sha256 "1202b15ad2add10daee1b22cd92af0fb0e27847d965641cf5c156a5d343519a5" => :el_capitan
+    sha256 "5aff4291cd37abe768efcbc4857bf3d0117aafd0e878251e4aef12a3d63eab89" => :sierra
   end
 
   option :universal

--- a/percona-server55.rb
+++ b/percona-server55.rb
@@ -11,7 +11,7 @@ class PerconaServer55 < Formula
   bottle do
     root_url "https://s3.amazonaws.com/sportngin-homebrew-bottles"
     rebuild 1
-    # sha256 "1202b15ad2add10daee1b22cd92af0fb0e27847d965641cf5c156a5d343519a5" => :el_capitan
+    sha256 "86938a33e57aff0aa08d65ecfd86a8e726c0d89bedddb37d307485b47c9ea93c" => :el_capitan
     sha256 "5aff4291cd37abe768efcbc4857bf3d0117aafd0e878251e4aef12a3d63eab89" => :sierra
   end
 

--- a/percona-server57.rb
+++ b/percona-server57.rb
@@ -50,10 +50,6 @@ class PerconaServer57 < Formula
               "COMMAND /usr/bin/libtool -static -o ${TARGET_LOCATION}",
               "COMMAND libtool -static -o ${TARGET_LOCATION}"
 
-    # Build without compiler or CPU specific optimization flags to facilitate
-    # compilation of gems and other software that queries `mysql-config`.
-    ENV.minimal_optimization
-
     args = %W[
       -DCMAKE_INSTALL_PREFIX=#{prefix}
       -DCMAKE_FIND_FRAMEWORK=LAST

--- a/percona-server57.rb
+++ b/percona-server57.rb
@@ -2,8 +2,8 @@
 class PerconaServer57 < Formula
   desc "Drop-in MySQL replacement"
   homepage "https://www.percona.com"
-  url "https://www.percona.com/downloads/Percona-Server-5.7/Percona-Server-5.7.11-4/source/tarball/percona-server-5.7.11-4.tar.gz"
-  sha256 "3634d2262e646db11b03837561acb0e084f33e5a597957506cf4c333ea811921"
+  url "https://www.percona.com/downloads/Percona-Server-5.7/Percona-Server-5.7.18-14/source/tarball/percona-server-5.7.18-14.tar.gz"
+  sha256 "4c617e2f9a1c601caebb5ff470c675e3d03ba3b8071cd3261ae24fe11671e3bd"
 
   keg_only 'Keg only with versioned data directory to allow multiple versions on one system.  See: https://www.percona.com/blog/2014/08/26/mysqld_multi-how-to-run-multiple-instances-of-mysql/'
 
@@ -123,8 +123,6 @@ class PerconaServer57 < Formula
     # Fix up the control script and link into bin
     inreplace "#{prefix}/support-files/mysql.server" do |s|
       s.gsub!(/^(PATH=".*)(")/, "\\1:#{HOMEBREW_PREFIX}/bin\\2")
-      # pidof can be replaced with pgrep from proctools on Mountain Lion
-      s.gsub!(/pidof/, "pgrep") if MacOS.version >= :mountain_lion
     end
 
     bin.install_symlink prefix/"support-files/mysql.server"

--- a/percona-server57.rb
+++ b/percona-server57.rb
@@ -9,8 +9,8 @@ class PerconaServer57 < Formula
 
   bottle do
     root_url "https://s3.amazonaws.com/sportngin-homebrew-bottles"
-    revision 2
-    sha256 "481b8210b1bf4700d8bb30cb43352abebd3042a4a30bfea8c4907c73dc97acdc" => :el_capitan
+    sha256 "d3c3af5b90b3c4dc4d6a97e0caa8e452f3bc05bb3245eccdd36378eebed59698" => :el_capitan
+    sha256 "51d228bbe6d205cd9b4d1110af297016290ef893b90b3bd044b8efaab7a1645c" => :sierra
   end
 
   option :universal


### PR DESCRIPTION
What
----------------------
- Updates percona-server57 to 5.7.18.14
- Adds new bottles for mongodb24 and both percona servers. (Bottle binaries to be handled separately)

Why
----------------------
To speed up installs of these components on Sierra/El Cap and deal with an initialization issue with the previous version of Percona 5.7 (see commentary on #10)

URLs
----
#10 

QA Plan
-------

QA will be done on an internal PR that uses these formulas.