### PR TITLE
Remove deprecated fails_with in Percona formulas

### DIFF
--- a/percona-server55.rb
+++ b/percona-server55.rb
@@ -28,11 +28,6 @@ class PerconaServer55 < Formula
   depends_on "pidof"
   depends_on "openssl"
 
-  fails_with :llvm do
-    build 2334
-    cause "https://github.com/mxcl/homebrew/issues/issue/144"
-  end
-
   def destination
     @destination ||= "mysql55"
   end

--- a/percona-server57.rb
+++ b/percona-server57.rb
@@ -26,11 +26,6 @@ class PerconaServer57 < Formula
   depends_on "pidof" unless MacOS.version >= :mountain_lion
   depends_on "openssl"
 
-  fails_with :llvm do
-    build 2334
-    cause "https://github.com/Homebrew/homebrew/issues/issue/144"
-  end
-
   resource "boost" do
     url "https://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.bz2"
     sha256 "727a932322d94287b62abb1bd2d41723eec4356a7728909e38adb65ca25241ca"


### PR DESCRIPTION
What
----------------------
Remove `fails_with` specification in Percona formulas. Gets rid of 

```
Warning: Calling fails_with :llvm is deprecated!
There is no replacement.
/usr/local/Homebrew/Library/Taps/sportngin/homebrew-homebrew/percona-server55.rb:31:in `<class:PerconaServer55>'
Please report this to the sportngin/homebrew tap!

Warning: Calling fails_with :llvm is deprecated!
There is no replacement.
/usr/local/Homebrew/Library/Taps/sportngin/homebrew-homebrew/percona-server55.rb:31:in `<class:PerconaServer55>'
Please report this to the sportngin/homebrew tap!

Warning: Calling fails_with :llvm is deprecated!
There is no replacement.
/usr/local/Homebrew/Library/Taps/sportngin/homebrew-homebrew/percona-server55.rb:31:in `<class:PerconaServer55>'
Please report this to the sportngin/homebrew tap!

Warning: Calling fails_with :llvm is deprecated!
There is no replacement.
/usr/local/Homebrew/Library/Taps/sportngin/homebrew-homebrew/percona-server55.rb:31:in `<class:PerconaServer55>'
Please report this to the sportngin/homebrew tap!

Warning: Calling fails_with :llvm is deprecated!
There is no replacement.
/usr/local/Homebrew/Library/Taps/sportngin/homebrew-homebrew/percona-server57.rb:29:in `<class:PerconaServer57>'
Please report this to the sportngin/homebrew tap!

Warning: Calling fails_with :llvm is deprecated!
There is no replacement.
/usr/local/Homebrew/Library/Taps/sportngin/homebrew-homebrew/percona-server57.rb:29:in `<class:PerconaServer57>'
Please report this to the sportngin/homebrew tap!

Warning: Calling fails_with :llvm is deprecated!
There is no replacement.
/usr/local/Homebrew/Library/Taps/sportngin/homebrew-homebrew/percona-server57.rb:29:in `<class:PerconaServer57>'
Please report this to the sportngin/homebrew tap!

Warning: Calling fails_with :llvm is deprecated!
There is no replacement.
/usr/local/Homebrew/Library/Taps/sportngin/homebrew-homebrew/percona-server57.rb:29:in `<class:PerconaServer57>'
Please report this to the sportngin/homebrew tap!
```
messages every time Homebrew runs.

Why
----------------------
> Why is this being changed?  Provide some context that may help future developers understand the reasoning behind these changes. Quote and/or link to requirements, keeping in mind that JIRA/A-HA/etc links may not be available in the future.

Deploy Plan
-----------
Merge the PR to deploy the changes.


QA Plan
-------
```
brew doctor # see current warnings above
export HOMEBREW_DEVELOPER=1
brew tap --full sportngin/homebrew-homebrew
cd `brew --repository sportngin/homebrew-homebrew`
git checkout remove-deprecated-fails-with
brew doctor # see warnings go away
git checkout master
unset HOMEBREW_DEVELOPER
```