### PR TITLE
Mongo24 high sierra build and bottle

### DIFF
--- a/mongodb24.rb
+++ b/mongodb24.rb
@@ -8,8 +8,7 @@ class Mongodb24 < Formula
     cellar :any_skip_relocation
     rebuild 1
     sha256 "4e6dbc25e9cb2a82d1047b4cc96314a3afe1afc6fb2f4d5f464201661419d644" => :sierra
-    sha256 "b83a20e8e440726fc0798d24d17a3781b811e959239d19d5ef0ee22aba7f5b83" => :el_capitan
-    sha256 "4b1d38da7eeb3ecfa7e2b5225fbe86c28f71285b33eb763d2ea4e7f49d9d5e42" => :high_sierra
+    sha256 "e82a70cf9925692bc302f7e534c896f1b14d38e588ea75b455be73c6bdecd432" => :high_sierra
   end
 
   patch do

--- a/mongodb24.rb
+++ b/mongodb24.rb
@@ -13,7 +13,12 @@ class Mongodb24 < Formula
 
   patch do
     url "https://github.com/mongodb/mongo/commit/be4bc7.diff"
-    sha256 "63592bb33dbe1662425a4a323a6ad33a6aa25d8e3c28b2bc48e34df57361eeed"
+    sha256 "92a395063451cb1fbdc13c0fe7db5c92704f8a5ac5810f5dad765d14831226ea"
+  end
+
+  patch do
+    url "https://raw.githubusercontent.com/sportngin/homebrew-homebrew/e191342/patches/mongo-2.4.12-pointer-comparison.patch"
+    sha256 ""
   end
 
   depends_on "scons" => :build

--- a/mongodb24.rb
+++ b/mongodb24.rb
@@ -9,6 +9,7 @@ class Mongodb24 < Formula
     rebuild 1
     sha256 "b83a20e8e440726fc0798d24d17a3781b811e959239d19d5ef0ee22aba7f5b83" => :el_capitan
     sha256 "4e6dbc25e9cb2a82d1047b4cc96314a3afe1afc6fb2f4d5f464201661419d644" => :sierra
+    sha256 "4b1d38da7eeb3ecfa7e2b5225fbe86c28f71285b33eb763d2ea4e7f49d9d5e42" => :high_sierra
   end
 
   patch do
@@ -18,7 +19,7 @@ class Mongodb24 < Formula
 
   patch do
     url "https://raw.githubusercontent.com/sportngin/homebrew-homebrew/e191342/patches/mongo-2.4.12-pointer-comparison.patch"
-    sha256 ""
+    sha256 "42df26a8fd73db69b68b83300baa2a33722e2b87732714b06d4ef7bee68fa08e"
   end
 
   depends_on "scons" => :build

--- a/mongodb24.rb
+++ b/mongodb24.rb
@@ -7,8 +7,8 @@ class Mongodb24 < Formula
     root_url "https://s3.amazonaws.com/sportngin-homebrew-bottles"
     cellar :any_skip_relocation
     rebuild 1
-    sha256 "b83a20e8e440726fc0798d24d17a3781b811e959239d19d5ef0ee22aba7f5b83" => :el_capitan
     sha256 "4e6dbc25e9cb2a82d1047b4cc96314a3afe1afc6fb2f4d5f464201661419d644" => :sierra
+    sha256 "b83a20e8e440726fc0798d24d17a3781b811e959239d19d5ef0ee22aba7f5b83" => :el_capitan
     sha256 "4b1d38da7eeb3ecfa7e2b5225fbe86c28f71285b33eb763d2ea4e7f49d9d5e42" => :high_sierra
   end
 

--- a/patches/mongo-2.4.12-pointer-comparison.patch
+++ b/patches/mongo-2.4.12-pointer-comparison.patch
@@ -1,0 +1,25 @@
+diff --git a/src/mongo/db/client.h b/src/mongo/db/client.h
+index 67063ddb14..b997553955 100644
+--- a/src/mongo/db/client.h
++++ b/src/mongo/db/client.h
+@@ -243,6 +243,6 @@ namespace mongo {
+     inline Client::GodScope::~GodScope() { cc()._god = _prev; }
+ 
+ 
+-    inline bool haveClient() { return currentClient.get() > 0; }
++    inline bool haveClient() { return currentClient.get() > (void*) 0; }
+ 
+ };
+diff --git a/src/mongo/db/namespace.h b/src/mongo/db/namespace.h
+index 9d011f684e..4aa1766e81 100644
+--- a/src/mongo/db/namespace.h
++++ b/src/mongo/db/namespace.h
+@@ -31,7 +31,7 @@ namespace mongo {
+         Namespace(const StringData& ns) { *this = ns; }
+         Namespace& operator=(const StringData& ns);
+ 
+-        bool hasDollarSign() const { return strchr( buf , '$' ) > 0;  }
++        bool hasDollarSign() const { return strchr( buf , '$' ) > (void*) 0;  }
+         void kill() { buf[0] = 0x7f; }
+         bool operator==(const char *r) const { return strcmp(buf, r) == 0; }
+         bool operator==(const Namespace& r) const { return strcmp(buf, r.buf) == 0; }

--- a/patches/mongo-2.4.12-pointer-comparison.patch
+++ b/patches/mongo-2.4.12-pointer-comparison.patch
@@ -1,3 +1,16 @@
+diff --git a/src/mongo/client/connpool.h b/src/mongo/client/connpool.h
+index 1b9fe2761a..465c53e165 100644
+--- a/src/mongo/client/connpool.h
++++ b/src/mongo/client/connpool.h
+@@ -301,7 +301,7 @@ namespace mongo {
+             return _conn;
+         }
+ 
+-        bool ok() const { return _conn > 0; }
++        bool ok() const { return _conn > (void*) 0; }
+ 
+         string getHost() const { return _host; }
+ 
 diff --git a/src/mongo/db/client.h b/src/mongo/db/client.h
 index 67063ddb14..b997553955 100644
 --- a/src/mongo/db/client.h
@@ -10,6 +23,19 @@ index 67063ddb14..b997553955 100644
 +    inline bool haveClient() { return currentClient.get() > (void*) 0; }
  
  };
+diff --git a/src/mongo/db/fts/fts_matcher.cpp b/src/mongo/db/fts/fts_matcher.cpp
+index ee462bbb00..67d3ce13d3 100644
+--- a/src/mongo/db/fts/fts_matcher.cpp
++++ b/src/mongo/db/fts/fts_matcher.cpp
+@@ -230,7 +230,7 @@ namespace mongo {
+          * @param haystack, raw string to be parsed
+          */
+         bool FTSMatcher::_phraseMatches( const string& phrase, const string& haystack ) const {
+-            return strcasestr( haystack.c_str(), phrase.c_str() ) > 0;
++            return strcasestr( haystack.c_str(), phrase.c_str() ) > (void*) 0;
+         }
+ 
+ 
 diff --git a/src/mongo/db/namespace.h b/src/mongo/db/namespace.h
 index 9d011f684e..4aa1766e81 100644
 --- a/src/mongo/db/namespace.h
@@ -23,3 +49,42 @@ index 9d011f684e..4aa1766e81 100644
          void kill() { buf[0] = 0x7f; }
          bool operator==(const char *r) const { return strcmp(buf, r) == 0; }
          bool operator==(const Namespace& r) const { return strcmp(buf, r.buf) == 0; }
+diff --git a/src/mongo/db/ops/update_internal.cpp b/src/mongo/db/ops/update_internal.cpp
+index 8046adfd49..67bfd814a6 100644
+--- a/src/mongo/db/ops/update_internal.cpp
++++ b/src/mongo/db/ops/update_internal.cpp
+@@ -1425,7 +1425,7 @@ namespace mongo {
+                     continue;
+                 }
+ 
+-                _hasDynamicArray = _hasDynamicArray || strstr( fieldName , ".$" ) > 0;
++                _hasDynamicArray = _hasDynamicArray || strstr( fieldName , ".$" ) > (void*) 0;
+ 
+                 Mod m;
+                 m.init( op , f , forReplication );
+diff --git a/src/mongo/s/d_state.cpp b/src/mongo/s/d_state.cpp
+index bca04ff565..ac2d0a2567 100644
+--- a/src/mongo/s/d_state.cpp
++++ b/src/mongo/s/d_state.cpp
+@@ -418,7 +418,7 @@ namespace mongo {
+         if ( ! shardingState.hasVersion( ns ) )
+             return false;
+ 
+-        return ShardedConnectionInfo::get(false) > 0;
++        return ShardedConnectionInfo::get(false) > (void*) 0;
+     }
+ 
+     class UnsetShardingCommand : public MongodShardCommand {
+diff --git a/src/mongo/s/shard.h b/src/mongo/s/shard.h
+index 41f819d3ae..1a19d15a65 100644
+--- a/src/mongo/s/shard.h
++++ b/src/mongo/s/shard.h
+@@ -283,7 +283,7 @@ namespace mongo {
+             _finishedInit = true;
+         }
+         
+-        bool ok() const { return _conn > 0; }
++        bool ok() const { return _conn > (void*) 0; }
+ 
+         /**
+            this just passes through excpet it checks for stale configs


### PR DESCRIPTION
Mongodb 2.4 no longer builds on High Sierra due to a number of pointer comparison errors that apparently used to only be warnings. Fix them with `(void*)` casts.

New high sierra bottle is available here:
http://www.caldersphere.net/homebrew/mongodb24-2.4.12.high_sierra.bottle.1.tar.gz