### PR TITLE
RKT-8764- accomodate homebrew 2.7.1+

### DIFF
--- a/elasticmq.rb
+++ b/elasticmq.rb
@@ -6,7 +6,7 @@ class Elasticmq < Formula
 
   bottle :unneeded
 
-  depends_on java: "1.8+"
+  depends_on "openjdk@8"
 
   def install
     jar_name = active_spec.downloader.basename


### PR DESCRIPTION
What
----------------------
Fix unsupported java dependency specification.  

Why
----------------------
```
==> Homebrew was updated to version 2.7.1
The changelog can be found at:
  https://github.com/Homebrew/brew/releases/tag/2.7.1
Error: elasticmq: Calling depends_on :java is disabled! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the sportngin/homebrew tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/sportngin/homebrew-homebrew/elasticmq.rb:9

```

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
> Reference commonly used Regression test plans on the [QA Wiki](https://github.com/sportngin/qa-tests/wiki)
> Fill in scenarios below in checklist format.
> Consider Regression scenarios (did we break something else related to this change) in addition to Happy Path (testing the new feature directly).
> Evaluate the risk level and label accordingly and ensure the QA Plan matches the risk level!

- [ ] to get testing, do:
```
export HOMEBREW_DEVELOPER=1
brew tap --full sportngin/homebrew-homebrew
cd `brew --repository sportngin/homebrew-homebrew`
git checkout RKT-8764_elasticmq_formula_update
```
- [ ] brew tap sportngin/homebrew
- [ ] brew install sportngin-brew-gem
- [ ] brew update succeeds
- [ ] `>~/sportsengine > ./setup`  succeeds
- [ ] get back to life as normal:
```
git checkout master
unset HOMEBREW_DEVELOPER
```